### PR TITLE
[WIP] Classes nested in tests break following test method detection

### DIFF
--- a/test_parser.py
+++ b/test_parser.py
@@ -46,14 +46,15 @@ class TestParser(ast.NodeVisitor):
     >>> list(set(map(parser.parse, (21, 22))))
     [(None, 'func_test')]
 
+    # nested classes are allowed
     >>> list(set(map(parser.parse, (25, 26, 27, 28, 31))))
-    [('ParentClass', None)]
+    [('ParentClassA', None)]
 
     >>> list(set(map(parser.parse, (29, 30))))
-    [('ParentClass', None)]
+    [('ParentClassA', None)]
 
     >>> list(set(map(parser.parse, (32, 33))))
-    [('ParentClass', 'parent_method')]
+    [('ParentClassA', 'parent_method')]
 
     # test decorated test case and decorated method
     >>> list(set(map(parser.parse, range(41, 44))))
@@ -66,6 +67,19 @@ class TestParser(ast.NodeVisitor):
     >>> parser = TestParser(source=module_source)
     >>> parser.parse(line=2)
     (None, 'test_first')
+
+    # classes defined in test are ignored
+    >>> list(set(map(parser.parse, (54, 55, 56))))
+    [('ParentClassB', None)]
+
+    >>> list(set(map(parser.parse, (57, 58))))
+    [('ParentClassB', 'test_foo')]
+
+    >>> list(set(map(parser.parse, (60, 61, 63, 67, 68, ))))
+    [('ParentClassB', 'test_a')]
+
+    >>> list(set(map(parser.parse, (70, 71))))
+    [('ParentClassB', 'test_b')]
     """
     nested_class = None
 

--- a/tests/_fixture.py
+++ b/tests/_fixture.py
@@ -22,7 +22,7 @@ def func_test():
     pass
 
 
-class ParentClass(AnotherClass):
+class ParentClassA(AnotherClass):
     class ChildClass:
         nested_property = True
 
@@ -48,4 +48,26 @@ class DecoratedTestClass(TestClass):
 
 class ParentInModuleClass(mymodule.TestClass):
     def test_me(self):
+        pass
+
+
+class ParentClassB(TestClass):
+    foo = 1
+
+    def test_foo(self):
+        pass
+
+    def test_a(self):
+        class ChildClass(object):
+            nested_property = True
+
+            def child_method(self):
+                pass
+
+            another_attribute = 'foo'
+
+        cl = ChildClass()
+        assert cl.nested_property
+
+    def test_b(self):
         pass


### PR DESCRIPTION
As seen in the attached test case 9f68faa, the failure is triggered by an attribute following a class method.
