### PR TITLE
Fix default settings file

### DIFF
--- a/SublimeTestPlier.sublime-settings
+++ b/SublimeTestPlier.sublime-settings
@@ -1,9 +1,11 @@
 {
-	"default_cmd": ["pytest", "-k {selection}", "--doctest-modules",
-					"--doctest-ignore-import-errors", "-v",
-					"{filename}::{test_class}::{test_func}"],
-
-	// a command that N arguments and calls these in an external terminal, see default:
-	// "default_external": ["python", "$packages/User/Test Plier/utils/run_externally.py"],
-	"debug": false
+  "default_cmd": [
+    "pytest",
+    "-k {selection}",
+    "--doctest-modules",
+    "--doctest-ignore-import-errors",
+    "-v",
+    "{filename}::{test_class}::{test_func}"
+  ],
+  "debug": false
 }


### PR DESCRIPTION
Currently the unit tests are broken since the default settings json is invalid. 
This PR includes:
* Remove comments from settings json so it is valid again
* Pretty-print settings json so it is easier to read for humans
