### PR TITLE
Created the setting "run_last_valid_test": true,

### DIFF
--- a/SublimeTestPlier.sublime-settings
+++ b/SublimeTestPlier.sublime-settings
@@ -18,5 +18,5 @@
   // With this setting, when running individual Unit Tests, it will run the last
   // function which had its name starting with `test_` and not the current one
   // named `my_function`.
-  "run_last_valid_test": true
+  "run_last_valid_test": false
 }

--- a/SublimeTestPlier.sublime-settings
+++ b/SublimeTestPlier.sublime-settings
@@ -7,5 +7,16 @@
     "-v",
     "{filename}::{test_class}::{test_func}"
   ],
-  "debug": false
+  "debug": false,
+
+  // If you select and ran the test `test_py` on the class UnitTest and latter
+  // moved from the test file to the source code on the class MyClass on the
+  // function `my_function`. If you try to run the unit test, the plugin will end
+  // up running `MyClass` and `my_function` as unit tests. But it is invalid as
+  // they are not tests.
+  //
+  // With this setting, when running individual Unit Tests, it will run the last
+  // function which had its name starting with `test_` and not the current one
+  // named `my_function`.
+  "run_last_valid_test": true
 }

--- a/python_test_plier.py
+++ b/python_test_plier.py
@@ -11,6 +11,11 @@ from . import utils
 class RunPythonTestsCommand(sublime_plugin.WindowCommand):
     external_runner = None
 
+    def __init__(self, window):
+        super().__init__(window)
+        self.old_func_name = ''
+        self.old_class_name = ''
+
     def ansi_installed(self):
         return 'sublimeansi' in list(map(str.lower, self.packages))
 
@@ -76,6 +81,13 @@ class RunPythonTestsCommand(sublime_plugin.WindowCommand):
             self.class_name = self.func_name = None
             return
         self.class_name, self.func_name = pattern
+
+        if self.func_name and not self.func_name.startswith( 'test_' ):
+            self.func_name = self.old_func_name
+            self.class_name = self.old_class_name
+
+        self.old_func_name = self.func_name
+        self.old_class_name = self.class_name
 
     def run(self, *args, **command_kwargs):
         utils._log('SublimeTestPlier running in debug mode')

--- a/python_test_plier.py
+++ b/python_test_plier.py
@@ -19,6 +19,9 @@ class RunPythonTestsCommand(sublime_plugin.WindowCommand):
         else:
             super().__init__()
 
+        settings = sublime.load_settings("SublimeTestPlier.sublime-settings")
+        self.run_last_valid_test = settings.get('run_last_valid_test', False)
+
         self.old_func_name = ''
         self.old_class_name = ''
 
@@ -88,12 +91,14 @@ class RunPythonTestsCommand(sublime_plugin.WindowCommand):
             return
         self.class_name, self.func_name = pattern
 
-        if self.func_name and not self.func_name.startswith( 'test_' ):
-            self.func_name = self.old_func_name
-            self.class_name = self.old_class_name
+        if self.run_last_valid_test:
 
-        self.old_func_name = self.func_name
-        self.old_class_name = self.class_name
+            if self.func_name and not self.func_name.startswith( 'test_' ):
+                self.func_name = self.old_func_name
+                self.class_name = self.old_class_name
+
+            self.old_func_name = self.func_name
+            self.old_class_name = self.class_name
 
     def run(self, *args, **command_kwargs):
         utils._log('SublimeTestPlier running in debug mode')

--- a/python_test_plier.py
+++ b/python_test_plier.py
@@ -11,7 +11,11 @@ from . import utils
 class RunPythonTestsCommand(sublime_plugin.WindowCommand):
     external_runner = None
 
-    def __init__(self, window):
+    def __init__(self, window=None):
+
+        if not window:
+            window = sublime.active_window()
+
         super().__init__(window)
         self.old_func_name = ''
         self.old_class_name = ''

--- a/python_test_plier.py
+++ b/python_test_plier.py
@@ -13,10 +13,12 @@ class RunPythonTestsCommand(sublime_plugin.WindowCommand):
 
     def __init__(self, window=None):
 
-        if not window:
-            window = sublime.active_window()
+        if window:
+            super().__init__(window)
 
-        super().__init__(window)
+        else:
+            super().__init__()
+
         self.old_func_name = ''
         self.old_class_name = ''
 


### PR DESCRIPTION
If you select and ran the test `test_py` on the class
UnitTest and latter moved from the test file to the source
code on the class MyClass on the function `my_function`. If
you try to run the unit test, the plugin will end up running
`MyClass` and `my_function` as unit tests. But it is invalid
as they are not tests.

With this setting, when running individual Unit Tests, it
will run the last function which had its name starting with
`test_` and not the current one named `my_function`.

(cherry picked from commit 73364a57f88e4f5f97461eb31e5db8ce48f37644)